### PR TITLE
Check if autoload.php exists

### DIFF
--- a/relevanssi-premium-snowball-stemmer.php
+++ b/relevanssi-premium-snowball-stemmer.php
@@ -34,7 +34,9 @@ require 'admin-menu.php';
  * @return string The stemmed word.
  */
 function relevanssi_premium_snowball_stemmer( $word ) {
-	require plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
+	if ( ! file_exists( plugin_dir_path( __FILE__ ) . 'vendor/autoload.php' ) ) {
+		require plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
+	}
 
 	$language = get_option( 'relevanssi_premium_snowball_stemmer_language', 'en' );
 	try {


### PR DESCRIPTION
Hi,

when installing this plugin/package via composer the dependencies will be located outside the plugin folder. A simple check if the `autoload.php` exists would make it work in such environments as well (Roots Bedrock in my case) because `wamania/php-stemmer` is already installed in the global vendor folder.